### PR TITLE
Downgrade all example's engine versions from nightly to 0.36.2

### DIFF
--- a/animation/Cargo.toml
+++ b/animation/Cargo.toml
@@ -3,12 +3,10 @@ members = ["editor", "executor", "executor-wasm", "executor-android", "game"]
 resolver = "2"
 
 [workspace.dependencies.fyrox]
-git = "https://github.com/FyroxEngine/Fyrox"
-rev = "e58a11847b37b11a79b7283af61dcd85ea9d2506"
+version = "0.36.2"
 
 [workspace.dependencies.fyroxed_base]
-git = "https://github.com/FyroxEngine/Fyrox"
-rev = "e58a11847b37b11a79b7283af61dcd85ea9d2506"
+version = "0.36.2"
 
 # Optimize the engine in debug builds, but leave project's code non-optimized.
 # By using this technique, you can still debug you code, but engine will be fully

--- a/blendshape/Cargo.toml
+++ b/blendshape/Cargo.toml
@@ -3,12 +3,10 @@ members = ["editor", "executor", "executor-wasm", "executor-android", "game"]
 resolver = "2"
 
 [workspace.dependencies.fyrox]
-git = "https://github.com/FyroxEngine/Fyrox"
-rev = "8408609581b2b86d5cc4431fb5352adb48835c7c"
+version = "0.36.2"
 
 [workspace.dependencies.fyroxed_base]
-git = "https://github.com/FyroxEngine/Fyrox"
-rev = "8408609581b2b86d5cc4431fb5352adb48835c7c"
+version = "0.36.2"
 
 # Optimize the engine in debug builds, but leave project's code non-optimized.
 # By using this technique, you can still debug you code, but engine will be fully

--- a/lightmap/Cargo.toml
+++ b/lightmap/Cargo.toml
@@ -4,13 +4,13 @@ members = ["editor", "executor", "executor-wasm", "executor-android", "game"]
 resolver = "2"
 
 [workspace.dependencies.fyrox]
-git = "https://github.com/FyroxEngine/Fyrox"
+version = "0.36.2"
 
 [workspace.dependencies.fyroxed_base]
-git = "https://github.com/FyroxEngine/Fyrox"
+version = "0.36.2"
 
 [workspace.dependencies.fyrox-scripts]
-git = "https://github.com/FyroxEngine/Fyrox"
+version = "0.36.2"
 
 # Optimize the engine in debug builds, but leave project's code non-optimized.
 # By using this technique, you can still debug you code, but engine will be fully
@@ -22,4 +22,3 @@ opt-level = 3
 
 [profile.release]
 debug = true
-

--- a/platformer/Cargo.toml
+++ b/platformer/Cargo.toml
@@ -3,10 +3,10 @@ members = ["editor", "executor", "executor-wasm", "game"]
 resolver = "2"
 
 [workspace.dependencies.fyrox]
-git = "https://github.com/FyroxEngine/Fyrox"
+version = "0.36.2"
 
 [workspace.dependencies.fyroxed_base]
-git = "https://github.com/FyroxEngine/Fyrox"
+version = "0.36.2"
 
 # Optimize the engine in debug builds, but leave project's code non-optimized.
 # By using this technique, you can still debug you code, but engine will be fully

--- a/sound/Cargo.toml
+++ b/sound/Cargo.toml
@@ -4,13 +4,13 @@ members = ["editor", "executor", "executor-wasm", "executor-android", "game"]
 resolver = "2"
 
 [workspace.dependencies.fyrox]
-git = "https://github.com/FyroxEngine/Fyrox"
+version = "0.36.2"
 
 [workspace.dependencies.fyroxed_base]
-git = "https://github.com/FyroxEngine/Fyrox"
+version = "0.36.2"
 
 [workspace.dependencies.fyrox-scripts]
-git = "https://github.com/FyroxEngine/Fyrox"
+version = "0.36.2"
 
 # Optimize the engine in debug builds, but leave project's code non-optimized.
 # By using this technique, you can still debug you code, but engine will be fully

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -4,10 +4,10 @@ members = ["editor", "executor", "executor-wasm", "executor-android", "game"]
 resolver = "2"
 
 [workspace.dependencies.fyrox]
-git = "https://github.com/FyroxEngine/Fyrox"
+version = "0.36.2"
 
 [workspace.dependencies.fyroxed_base]
-git = "https://github.com/FyroxEngine/Fyrox"
+version = "0.36.2"
 
 # Optimize the engine in debug builds, but leave project's code non-optimized.
 # By using this technique, you can still debug you code, but engine will be fully


### PR DESCRIPTION
Currently 4 out of 6 examples in this repository do not compile because of interface changes in game scripts. I think the best solution to it is to switch the engine versions from nightly back to the latest release version (0.36.2). In this way, we do not need to worry about updating this repository as we develop the nightly version, and there will be no risk for newcomers to bump into compatibility issues when trying this engine.

I've tested the functionality of all 6 examples after I have made these changes:
![editor_CmISRRjTLB](https://github.com/user-attachments/assets/2f7ea021-eddb-40fd-8120-5567c65229fb)
<img width="1280" height="747" alt="editor_wgQtS1MpiD" src="https://github.com/user-attachments/assets/621830b0-490c-4e64-8c9c-31b568886780" />
![editor_rr5g948Ij0](https://github.com/user-attachments/assets/f3bc17ca-4f16-441c-bdd8-f7a75cb10967)
<img width="1280" height="747" alt="editor_PhIvylyJlO" src="https://github.com/user-attachments/assets/1961cbd8-049e-4ab9-961d-e104a19636e8" />
![editor_jOCASGYwfE](https://github.com/user-attachments/assets/61004f77-a532-442d-8d04-8c177ea3d5ee)
![editor_66Ny9QwwFM](https://github.com/user-attachments/assets/78b6e08e-368f-41e2-864f-b676d14741b1)
